### PR TITLE
Add Supabase auth and progress tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ npm run dev
 ```
 
 Open `http://localhost:3000` in your browser.
+
+## Supabase setup
+
+Create a project on [Supabase](https://supabase.com/) and copy the URL and anon key to a `.env.local` file inside the `app` directory:
+
+```
+NEXT_PUBLIC_SUPABASE_URL=your-project-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+```
+
+Run the SQL in `supabase/progress.sql` to create the `progress` table used for storing learning progress.

--- a/app/app/api/emojis/route.js
+++ b/app/app/api/emojis/route.js
@@ -1,0 +1,10 @@
+import { loadEmojiData } from '@/lib/loadEmojiData'
+
+export async function GET() {
+  try {
+    const data = await loadEmojiData()
+    return Response.json(data)
+  } catch (err) {
+    return Response.json({ error: 'Failed to load data' }, { status: 500 })
+  }
+}

--- a/app/app/api/save-progress/route.js
+++ b/app/app/api/save-progress/route.js
@@ -1,0 +1,27 @@
+import { supabase } from '@/lib/supabaseClient'
+
+export async function POST(request) {
+  const { emoji, known } = await request.json()
+  const { data: { session }, error: sessionError } = await supabase.auth.getSession()
+
+  if (sessionError) {
+    return Response.json({ error: sessionError.message }, { status: 500 })
+  }
+
+  if (!session) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { error } = await supabase.from('progress').insert({
+    user_id: session.user.id,
+    emoji,
+    known,
+    timestamp: new Date().toISOString(),
+  })
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 })
+  }
+
+  return Response.json({ success: true })
+}

--- a/app/app/challenge/page.js
+++ b/app/app/challenge/page.js
@@ -1,31 +1,22 @@
 'use client'
-import { useState } from 'react'
-
-const choices = ['👋', '🌎', '😊', '🍕', '🏃']
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabaseClient'
+import EmojiPhraseChallenge from '../components/EmojiPhraseChallenge'
 
 export default function Challenge() {
-  const [phrase, setPhrase] = useState([])
+  const router = useRouter()
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session) router.push('/')
+    })
+  }, [router])
+
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-8 space-y-8">
-      <h1 className="text-2xl font-semibold">Build a phrase</h1>
-      <div className="flex gap-2">
-        {choices.map((c, idx) => (
-          <button
-            key={idx}
-            onClick={() => setPhrase([...phrase, c])}
-            className="text-3xl p-2 rounded bg-gray-100 hover:bg-gray-200"
-          >
-            {c}
-          </button>
-        ))}
-      </div>
-      <div className="text-4xl h-12 flex items-center">{phrase.join(' ')}</div>
-      <button
-        onClick={() => setPhrase([])}
-        className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300"
-      >
-        Clear
-      </button>
+      <h1 className="text-2xl font-semibold">Guess the phrase</h1>
+      <EmojiPhraseChallenge />
     </div>
   )
 }

--- a/app/app/components/EmojiPhraseChallenge.js
+++ b/app/app/components/EmojiPhraseChallenge.js
@@ -1,0 +1,84 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+export default function EmojiPhraseChallenge() {
+  const [phrases, setPhrases] = useState([])
+  const [index, setIndex] = useState(0)
+  const [guess, setGuess] = useState('')
+  const [attempts, setAttempts] = useState(3)
+  const [status, setStatus] = useState('playing') // 'playing' | 'correct' | 'failed'
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    fetch('/emoji-phrases.json')
+      .then((res) => res.json())
+      .then((data) => setPhrases(data))
+      .catch(() => setPhrases([]))
+  }, [])
+
+  if (!phrases.length) return <div>Loading...</div>
+
+  const current = phrases[index]
+
+  function checkAnswer() {
+    const normalized = guess.trim().toLowerCase()
+    const correct =
+      normalized === current.meaning_en.toLowerCase() ||
+      normalized === current.meaning_it.toLowerCase()
+
+    if (correct) {
+      setStatus('correct')
+      setMessage(`Correct! ${current.meaning_en} (${current.meaning_it})`)
+    } else if (attempts > 1) {
+      const remain = attempts - 1
+      setAttempts(remain)
+      setMessage(`Try again. ${remain} attempt${remain === 1 ? '' : 's'} left.`)
+    } else {
+      setStatus('failed')
+      setMessage(
+        `Out of attempts! Solution: ${current.meaning_en} (${current.meaning_it})`
+      )
+    }
+  }
+
+  function nextPhrase() {
+    setGuess('')
+    setAttempts(3)
+    setStatus('playing')
+    setMessage('')
+    setIndex((idx) => (idx + 1) % phrases.length)
+  }
+
+  return (
+    <div className="space-y-4 text-center">
+      <div className="text-6xl">{current.emojis.join(' ')}</div>
+      {status === 'playing' && (
+        <div className="space-y-2">
+          <input
+            type="text"
+            value={guess}
+            onChange={(e) => setGuess(e.target.value)}
+            className="p-2 border rounded w-full max-w-xs"
+            placeholder="Your guess"
+          />
+          <button
+            onClick={checkAnswer}
+            className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300"
+          >
+            Guess
+          </button>
+        </div>
+      )}
+      {message && <div className="mt-2 font-medium">{message}</div>}
+      {status !== 'playing' && (
+        <button
+          onClick={nextPhrase}
+          className="mt-2 px-4 py-2 rounded bg-gray-200 hover:bg-gray-300"
+        >
+          Next
+        </button>
+      )}
+    </div>
+  )
+}

--- a/app/app/learn/page.js
+++ b/app/app/learn/page.js
@@ -1,7 +1,18 @@
 'use client'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabaseClient'
 import EmojiQuiz from '../components/EmojiQuiz'
 
 export default function Learn() {
+  const router = useRouter()
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session) router.push('/')
+    })
+  }, [router])
+
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-8 space-y-8">
       <h1 className="text-2xl font-semibold">Learn words</h1>

--- a/app/app/login/page.js
+++ b/app/app/login/page.js
@@ -1,0 +1,44 @@
+'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabaseClient'
+
+export default function Login() {
+  const [email, setEmail] = useState('')
+  const [message, setMessage] = useState('')
+  const router = useRouter()
+
+  async function handleLogin(e) {
+    e.preventDefault()
+    const { error } = await supabase.auth.signInWithOtp({ email })
+    if (error) {
+      setMessage(error.message)
+    } else {
+      setMessage('Check your email for the magic link!')
+    }
+  }
+
+  supabase.auth.onAuthStateChange((_event, session) => {
+    if (session) router.push('/learn')
+  })
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-8 space-y-4">
+      <h1 className="text-2xl font-semibold">Sign In</h1>
+      <form onSubmit={handleLogin} className="space-y-2">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          placeholder="Your email"
+          className="p-2 border rounded w-64"
+        />
+        <button className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300">
+          Send Magic Link
+        </button>
+      </form>
+      {message && <div className="mt-2">{message}</div>}
+    </div>
+  )
+}

--- a/app/app/page.js
+++ b/app/app/page.js
@@ -1,14 +1,43 @@
 'use client'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import LanguageSelector from './components/LanguageSelector'
+import { supabase } from '@/lib/supabaseClient'
 
 export default function Home() {
+  const [session, setSession] = useState(null)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session)
+    })
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+    })
+    return () => {
+      listener.subscription.unsubscribe()
+    }
+  }, [])
+
+  function signOut() {
+    supabase.auth.signOut()
+  }
+
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-8 space-y-8">
       <LanguageSelector />
       <Link href="/challenge" className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">
         Challenge
       </Link>
+      {session ? (
+        <button onClick={signOut} className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">
+          Sign out
+        </button>
+      ) : (
+        <Link href="/login" className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">
+          Sign in
+        </Link>
+      )}
     </div>
   )
 }

--- a/app/lib/loadEmojiData.js
+++ b/app/lib/loadEmojiData.js
@@ -1,0 +1,8 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+export async function loadEmojiData() {
+  const filePath = path.join(process.cwd(), 'public', 'emoji-data.json')
+  const data = await fs.readFile(filePath, 'utf-8')
+  return JSON.parse(data)
+}

--- a/app/lib/supabaseClient.js
+++ b/app/lib/supabaseClient.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.50.3",
         "next": "15.3.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -967,6 +968,81 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.70.0.tgz",
+      "integrity": "sha512-BaAK/tOAZFJtzF1sE3gJ2FwTjLf4ky3PSvcvLGEgEmO4BSBkwWKu8l67rLLIBZPDnCyV7Owk2uPyKHa0kj5QGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.15.tgz",
+      "integrity": "sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "isows": "^1.0.7",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.50.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.50.3.tgz",
+      "integrity": "sha512-Ld42AbfSXKnbCE2ObRvrGC5wj9OrfTOzswQZg0OcGQGx+QqcWYN/IqsLqrt4gCFrD57URbNRfGESSWzchzKAuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.70.0",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.15",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -1289,6 +1365,30 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
+      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.35.1",
@@ -4041,6 +4141,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -5774,6 +5889,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -5931,6 +6052,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
+    },
     "node_modules/unrs-resolver": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.10.1.tgz",
@@ -5974,6 +6101,22 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -6089,6 +6232,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/app/package.json
+++ b/app/package.json
@@ -9,15 +9,16 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.50.3",
+    "next": "15.3.5",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.5"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4"
   }
 }

--- a/app/public/emoji-data.json
+++ b/app/public/emoji-data.json
@@ -1,0 +1,5 @@
+[
+  { "emoji": "🐱", "meaning_en": "cat", "meaning_it": "gatto", "meaning_es": "gato" },
+  { "emoji": "🚗", "meaning_en": "car", "meaning_it": "macchina", "meaning_es": "coche" },
+  { "emoji": "🍎", "meaning_en": "apple", "meaning_it": "mela", "meaning_es": "manzana" }
+]

--- a/app/public/emoji-phrases.json
+++ b/app/public/emoji-phrases.json
@@ -1,0 +1,17 @@
+[
+  {
+    "emojis": ["🍎", "👨‍🏫"],
+    "meaning_en": "a teacher with an apple",
+    "meaning_it": "un insegnante con una mela"
+  },
+  {
+    "emojis": ["🏃", "🌧️"],
+    "meaning_en": "running in the rain",
+    "meaning_it": "correre sotto la pioggia"
+  },
+  {
+    "emojis": ["🎂", "🎉", "🎁"],
+    "meaning_en": "birthday party with presents",
+    "meaning_it": "festa di compleanno con regali"
+  }
+]

--- a/supabase/progress.sql
+++ b/supabase/progress.sql
@@ -1,0 +1,7 @@
+-- SQL schema for tracking emoji learning progress
+create table if not exists progress (
+  user_id uuid references auth.users not null,
+  emoji text not null,
+  known boolean not null,
+  timestamp timestamptz default now()
+);


### PR DESCRIPTION
## Summary
- add login page that uses Supabase magic-link auth
- show sign-in/out on the homepage
- provide API route to store learning progress in Supabase
- include SQL for the `progress` table

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686b7a6119d8832198b599c7fb751a5e